### PR TITLE
Add build status badge and short delete flag for stop command

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -63,4 +63,4 @@ jobs:
           tag: ${{ github.ref }}
           prerelease: ${{ env.PRERELEASE }}
           release_name: "Bovine ${{ env.VERSION }}"
-          body: "Please refer to CHANGELOG.md for information on this release."
+          body: "Please refer to **[CHANGELOG.md](https://github.com/nickgerace/bovine/blob/main/CHANGELOG.md)** for information on this release."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Bovine
 
-[![tag](https://img.shields.io/github/v/tag/nickgerace/bovine?label=version&style=flat-square&logo=github&color=blue)](https://github.com/nickgerace/bovine/releases/latest)
+[![release](https://img.shields.io/github/v/release/nickgerace/bovine?sort=semver&style=flat-square&logo=github&color=blue)](https://github.com/nickgerace/bovine/releases/latest)
 [![crates.io](https://img.shields.io/crates/v/bovine?style=flat-square&logo=rust&color=orange)](https://crates.io/crates/bovine)
-[![license](https://img.shields.io/github/license/nickgerace/bovine?style=flat-square&color=green)](./LICENSE)
+[![build](https://img.shields.io/github/workflow/status/nickgerace/bovine/merge?style=flat-square)](https://github.com/nickgerace/bovine/actions)
+[![license](https://img.shields.io/github/license/nickgerace/bovine?style=flat-square&color=purple)](./LICENSE)
 
 Manage single node Rancher clusters with a single binary, `bovine`.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,14 +4,25 @@ This document contains all information related to release.
 
 ## Checklist
 
+This checklist details the `bovine` release process.
+
+### Preparation
+
 - [ ] Checkout (or create a branch of) `main` at its latest commit.
 - [ ] Change the `version` field in `Cargo.toml` to `$NEW_TAG`.
 - [ ] Run `make release` and verify that everything looks/works as expected.
-- [ ] (Skip for release candidates) Change the version in `CHANGELOG.md` and uncomment the line, `<!--The latest version contains all changes.-->`.
+- [ ] (Skip for release candidates) change the version in `CHANGELOG.md` and uncomment the line, `<!--The latest version contains all changes.-->`.
 - [ ] Create a commit with the following message: `Update to $NEW_TAG`. Do not push (or merge) the commit.
 - [ ] Test and verify the publishing workflow: `cargo publish --dry-run`.
 - [ ] Finally, push (or merge) the preparation commit into `main`.
-- [ ] Once the prepation commit has been pushed (or merged) into `main`, tag with `git tag $NEW_TAG` and push the tag: `git push --tags origin main`.
+
+### Release Time
+
+- [ ] Once the prepation commit has been pushed (or merged) into `main`, checkout and/or update `main`.
+- [ ] Tag with `git tag $NEW_TAG` and push the tag: `git push --tags origin main`.
 - [ ] Now, publish the crate: `cargo publish`.
+
+### Post Release
+
 - [ ] Check the [crate](https://crates.io/crates/bovine) on `crates.io`.
-- [ ] Check the [docs](https://docs.rs/bovine) on `docs.rs`.
+- [ ] Check the [release](https://github.com/nickgerace/bovine/releases) on the repository's releases page.

--- a/src/types/cli.rs
+++ b/src/types/cli.rs
@@ -122,6 +122,7 @@ pub struct Stop {
     pub container_id: Option<String>,
     #[clap(
         long,
+        short,
         about = "Delete container after stopping it (warning: this flag will permanently delete selected container(s))"
     )]
     pub delete: bool,


### PR DESCRIPTION
Add build status badge. Change tag badge to highest semver release badge. Add short flag for the long delete option when executing bovine stop. Add changelog hyperlink for future releases.

### Linked Issue(s)
Closes #31 
Closes #30
Closes #29
Closes #28
