### PR TITLE
Add option to print entire bootstrap password log line

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
         "restart error occurred (perhaps there is already a container using the same port(s))"
     )]
     DockerContainerRestartFailure,
+    #[error("could not find bootstrap password within the logs")]
+    BootstrapPasswordNotFound,
 
     #[error("could not find config for inspected container: {0}")]
     DockerContainerConfigNotFound(String),
@@ -30,7 +32,7 @@ pub enum Error {
     #[error("splitting OCI image name into its short name and tag failed: {0}")]
     OCIImageSplitFailure(String),
     #[error("could not find bootstrap password within the line: {0}")]
-    LogMessageScrapingFailure(LogOutput),
+    BootstrapPasswordScrapingFailure(LogOutput),
 
     #[error("container not managed by Bovine")]
     NotBovineContainer,

--- a/src/types/cli.rs
+++ b/src/types/cli.rs
@@ -75,7 +75,7 @@ pub struct List {
 #[derive(Clap, Debug)]
 pub struct Logs {
     #[clap(
-        about = "ID of the Rancher container running or not-running (if empty, will select a Rancher container at random)"
+        about = "ID of the Rancher container running or not-running (if empty, it will select a Rancher container at random, which is useful when only one container is running)"
     )]
     pub container_id: Option<String>,
     #[clap(long, short, about = "Follow logs")]
@@ -87,6 +87,13 @@ pub struct Logs {
         about = "Attempt to find the bootstrap password (>=v2.6) (caution: finding the bootstrap password relies on parsing Rancher logs and is not an API call)"
     )]
     pub find_bootstrap_password: bool,
+    #[clap(
+        long,
+        short,
+        requires = "find-bootstrap-password",
+        about = "Display the entire log line where the bootstrap password was found"
+    )]
+    pub verbose: bool,
 }
 
 #[derive(Clap, Debug)]


### PR DESCRIPTION
Add option to print entire bootstrap password log line. Return an error
if the bootstrap password is not found.

### Linked Issue(s)
Closes #35 
Closes #34
