### PR TITLE
Use hyphens instead of underscores in version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ Let's print that information out, just to get the hang of it.
   "docker": {
     "version": "20.10.8",
     "os/arch": "linux/amd64",
-    "api_version": "1.41",
-    "linux_kernel_version": "5.11.0-27-generic",
-    "git_commit": "75249d8"
+    "api-version": "1.41",
+    "linux-kernel-version": "5.11.0-27-generic",
+    "git-commit": "75249d8"
   }
 }
 
@@ -192,10 +192,10 @@ Let's try it on a Linux host.
   "docker": {
     "version": "20.10.8",
     "os/arch": "linux/amd64",
-    "api_version": "1.41",
-    "linux_kernel_version": "5.11.0-27-generic",
-    "git_commit": "75249d8"
-    "socket_path": "/foo/bar/docker.sock"
+    "api-version": "1.41",
+    "linux-kernel-version": "5.11.0-27-generic",
+    "git-commit": "75249d8"
+    "socket-path": "/foo/bar/docker.sock"
   }
 }
 ```

--- a/src/types/version.rs
+++ b/src/types/version.rs
@@ -21,12 +21,16 @@ pub struct DockerVersion {
     #[serde(rename(serialize = "os/arch"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_arch: Option<String>,
+    #[serde(rename(serialize = "api-version"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename(serialize = "linux-kernel-version"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub linux_kernel_version: Option<String>,
+    #[serde(rename(serialize = "git-commit"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_commit: Option<String>,
+    #[serde(rename(serialize = "docker-socket-path"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docker_socket_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
### Linked Issue(s)
Related #44 