### PR TITLE
Use INFO logging over printing to STDOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-The latest version contains all changes.
+<!-- The latest version contains all changes. -->
+
+### Changed
+
+- All direct-to-STDOUT statements to use `INFO` logging (except when printing formatted logs)
+
+### Removed
+
+- The ability to run in debug mode while using the `logs` subcommand (avoid logging a formatted log)
 
 ## [0.2.0] - 2021-09-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,6 @@ checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -262,17 +261,6 @@ name = "futures-core"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -312,13 +300,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
@@ -763,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
+checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
 dependencies = [
  "rustversion",
  "serde",
@@ -774,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
+checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -825,18 +810,18 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ repository = "https://github.com/nickgerace/bovine"
 
 [dependencies]
 anyhow = "1"
-bollard = "0"
-futures = "0"
+bollard = { version = "0", default_features = false }
+futures = { version = "0", default_features = false }
 log = "0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,15 @@ BINARY:=$(MAKEPATH)/target/release/bovine
 
 all: prepare build
 
-final: update prepare scan build
+final: prepare scan build
 
 debug: prepare
 	cd $(MAKEPATH); cargo build
 
 build:
 	cd $(MAKEPATH); cargo build --release
-	du -h $(BINARY)
-	strip $(BINARY)
-	du -h $(BINARY)
+	@du -h $(BINARY)
+	@du $(BINARY)
 
 prepare:
 	cd $(MAKEPATH); cargo update
@@ -33,3 +32,8 @@ release:
 	cd $(MAKEPATH); cargo clippy -- -D warnings
 	cd $(MAKEPATH); cargo test -- --nocapture
 	cd $(MAKEPATH); cargo build --release
+
+compare:
+	cd $(MAKEPATH); cargo build --release
+	@du $(BINARY)
+	@du ~/.cargo/bin/bovine

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -48,7 +48,8 @@ Having said that, this design point is subject to change.
 ## Style Guide
 
 Executing `cargo +nightly fmt` within the repository should suffice for most users.
-However, logging and printing to `STDOUT` require manual review:
+However, logging and printing requires manual review for style:
 
-- **logging**: log messages should start with lowercase letters and _usually_ not end with punctuation
-- **printing**: user messages printed to `STDOUT` are flexible in their style, but should start with uppercase letters when possible
+- **logging (non-`INFO`)**: log messages should start with lowercase letters and _usually_ not end with punctuation
+- **logging (`INFO`)**: user messages intended for the user (`INFO`) are flexible in their style, but should start with uppercase letters when possible
+- **printing**: printing directly to `STDOUT` or `STDERR` is only permitted when re-printing a formatted log

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,5 +1,6 @@
 use crate::{consts::platform::NEWLINE, docker, error::Error, rancher, types::cli::Get};
 use anyhow::Result;
+use log::info;
 
 pub async fn get(opt: &Get, docker_socket_path: Option<String>) -> Result<()> {
     let docker = docker::docker_client(docker_socket_path).await?;
@@ -7,7 +8,7 @@ pub async fn get(opt: &Get, docker_socket_path: Option<String>) -> Result<()> {
 
     match &inspection.state {
         Some(s) => {
-            println!(
+            info!(
                 "{},{}{}",
                 serde_json::to_string_pretty(&rancher::build_config(
                     match inspection.config {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,11 +1,12 @@
 use crate::{consts::platform::NEWLINE, docker, types::cli::List};
 use anyhow::Result;
+use log::info;
 
 pub async fn list(opt: &List, docker_socket_path: Option<String>) -> Result<()> {
     let docker = docker::docker_client(docker_socket_path).await?;
     let list = docker::list(&docker, opt.short, opt.running).await?;
     if !list.is_empty() {
-        println!("{}", list.join(NEWLINE));
+        info!("{}", list.join(NEWLINE));
     }
     Ok(())
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -3,6 +3,9 @@ use anyhow::Result;
 use bollard::container::LogsOptions;
 use futures::StreamExt;
 
+// We do not want to log a formatted log, so we print directly to STDOUT and STDERR as needed.
+// In addition, we want to send stream errors to STDERR, and _all_ given logs to STDOUT.
+// This pattern would be difficult to make user friendly (and maintaible) if implemented with logging.
 pub async fn logs(opt: &Logs, docker_socket_path: Option<String>) -> Result<()> {
     let docker = docker::docker_client(docker_socket_path).await?;
 

--- a/src/commands/restart.rs
+++ b/src/commands/restart.rs
@@ -1,11 +1,12 @@
 use crate::{docker, error::Error, rancher, types::cli::Restart, util};
 use anyhow::Result;
+use log::info;
 
 pub async fn restart(opt: &Restart, docker_socket_path: Option<String>) -> Result<()> {
     let docker = docker::docker_client(docker_socket_path).await?;
     match rancher::is_bovine(&docker.inspect_container(&opt.container_id, None).await?)? {
         true => {
-            println!("Restarting Rancher container: {}", &opt.container_id);
+            info!("Restarting Rancher container: {}", &opt.container_id);
             match docker.restart_container(&opt.container_id, None).await {
                 Ok(_) => Ok(()),
                 Err(e) => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -4,6 +4,7 @@ use bollard::{
     container,
     models::{HostConfig, PortBinding, RestartPolicy, RestartPolicyNameEnum},
 };
+use log::info;
 use std::collections::HashMap;
 
 pub async fn run(opt: &Run, docker_socket_path: Option<String>) -> Result<()> {
@@ -118,7 +119,7 @@ pub async fn run(opt: &Run, docker_socket_path: Option<String>) -> Result<()> {
     };
 
     match opt.dry_run {
-        true => println!("{}", serde_json::to_string_pretty(&container_config)?),
+        true => info!("{}", serde_json::to_string_pretty(&container_config)?),
         false => {
             let docker = docker::docker_client(docker_socket_path).await?;
             docker::pull_image(&docker, &image, opt.common.force_pull).await?;

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,12 +1,13 @@
 use crate::{docker, error::Error, types::cli::Stop};
 use anyhow::Result;
+use log::info;
 
 pub async fn stop(opt: &Stop, docker_socket_path: Option<String>) -> Result<()> {
     let docker = docker::docker_client(docker_socket_path).await?;
     match &opt.container_id {
         Some(id) => match opt.dry_run {
             true => {
-                println!("{}", &id);
+                info!("{}", &id);
                 Ok(())
             }
             false => docker::stop_container(&docker, id, opt.delete).await,
@@ -20,7 +21,7 @@ pub async fn stop(opt: &Stop, docker_socket_path: Option<String>) -> Result<()> 
             // non-running containers.
             for list_item in docker::list(&docker, true, !opt.delete).await? {
                 match opt.dry_run {
-                    true => println!("{}", &list_item),
+                    true => info!("{}", &list_item),
                     false => docker::stop_container(&docker, &list_item, opt.delete).await?,
                 }
             }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,6 +1,7 @@
 use crate::{consts, docker, error::Error, rancher, types::cli::Upgrade, util};
 use anyhow::Result;
 use bollard::{container::Config, models::HostConfig};
+use log::info;
 
 pub async fn upgrade(opt: &Upgrade, docker_socket_path: Option<String>) -> Result<()> {
     let docker = docker::docker_client(docker_socket_path).await?;
@@ -35,7 +36,7 @@ pub async fn upgrade(opt: &Upgrade, docker_socket_path: Option<String>) -> Resul
 
     docker::stop_container(&docker, &opt.container_id, false).await?;
     let volumes_from = vec![opt.container_id.to_owned()];
-    println!(
+    info!(
         "Created temporary container for volume backup: {}",
         util::get_first_n_chars(
             docker
@@ -64,6 +65,6 @@ pub async fn upgrade(opt: &Upgrade, docker_socket_path: Option<String>) -> Resul
         rancher::build_config(config.clone(), host_config.clone(), Some(volumes_from)),
     )
     .await?;
-    println!("Upgrade from [{}] to [{}] complete", old_image, new_image);
+    info!("Upgrade from [{}] to [{}] complete", old_image, new_image);
     Ok(())
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -5,14 +5,14 @@ use crate::{
     util,
 };
 use anyhow::Result;
-use log::error;
+use log::{error, info};
 use serde_json;
 use std::env::consts;
 
 pub async fn version(opt: &cli::Version, docker_socket_path: Option<String>) -> Result<()> {
     match opt.short {
         true => {
-            println!("{}", VERSION);
+            info!("{}", VERSION);
             Ok(())
         }
         false => full_version(docker_socket_path).await,
@@ -20,7 +20,7 @@ pub async fn version(opt: &cli::Version, docker_socket_path: Option<String>) -> 
 }
 
 async fn full_version(docker_socket_path: Option<String>) -> Result<()> {
-    println!(
+    info!(
         "{}",
         serde_json::to_string_pretty(&version::Version {
             bovine: version::BovineVersion {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -12,7 +12,7 @@ use bollard::{
     Docker, API_DEFAULT_VERSION,
 };
 use futures::TryStreamExt;
-use log::{debug, error};
+use log::{debug, error, info};
 use std::collections::HashMap;
 
 pub async fn docker_client(socket_path: Option<String>) -> Result<Docker, Error> {
@@ -62,10 +62,10 @@ pub async fn stop_container(docker: &Docker, container_id: &str, delete: bool) -
         true => {
             debug!("processing container for stop: {}", container_id);
             match docker.stop_container(container_id, None).await {
-                Ok(_) => println!("Stopped Rancher container: {}", container_id),
+                Ok(_) => info!("Stopped Rancher container: {}", container_id),
                 Err(e) => match e {
                     DockerResponseNotModifiedError { message: _ } => {
-                        println!(
+                        info!(
                             "Container not modified (may have already been stopped): {}",
                             container_id
                         )
@@ -79,10 +79,10 @@ pub async fn stop_container(docker: &Docker, container_id: &str, delete: bool) -
             if delete {
                 debug!("processing container for delete: {}", container_id);
                 match docker.remove_container(container_id, None).await {
-                    Ok(_) => println!("Deleted Rancher container: {}", container_id),
+                    Ok(_) => info!("Deleted Rancher container: {}", container_id),
                     Err(e) => match e {
                         DockerResponseNotFoundError { message: _ } => {
-                            println!(
+                            info!(
                                 "Container not found (may have already been deleted): {}",
                                 container_id
                             )
@@ -106,7 +106,7 @@ pub async fn stop_container(docker: &Docker, container_id: &str, delete: bool) -
                         }
                     }
                 }
-                println!("Deleted volumes for container: {}", container_id);
+                info!("Deleted volumes for container: {}", container_id);
             }
             Ok(())
         }
@@ -147,15 +147,15 @@ pub async fn pull_image(docker: &Docker, image: &str, force_pull: bool) -> Resul
     {
         Ok(o) => match o.is_empty() {
             true => {
-                println!("Pulling [{}], this may take awhile...", image);
+                info!("Pulling [{}], this may take awhile...", image);
                 pull_image_helper(docker, image).await
             }
             false if force_pull => {
-                println!("Force pulling [{}], this may take awhile...", image);
+                info!("Force pulling [{}], this may take awhile...", image);
                 pull_image_helper(docker, image).await
             }
             false => {
-                println!("Image found locally: [{}]", image);
+                info!("Image found locally: [{}]", image);
                 Ok(())
             }
         },

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,4 +40,8 @@ pub enum Error {
     StopOrDeleteContainerNotProvided,
     #[error("container ID must be provided or at least one running Rancher container must exist")]
     LogsContainerNotProvided,
+    #[error(
+        "cannot use debug logging while following container logs (risk of logging a formatted log)"
+    )]
+    LogsDebugModeEnabled,
 }

--- a/src/rancher.rs
+++ b/src/rancher.rs
@@ -11,6 +11,7 @@ use bollard::{
     },
     Docker,
 };
+use log::info;
 use std::collections::HashMap;
 
 pub async fn launch_rancher(docker: Docker, config: Config<String>) -> Result<()> {
@@ -19,7 +20,7 @@ pub async fn launch_rancher(docker: Docker, config: Config<String>) -> Result<()
         .await?
         .id;
     docker.start_container::<String>(&id, None).await?;
-    println!(
+    info!(
         "Rancher container is running: {}",
         util::get_first_n_chars(id, 12)
     );


### PR DESCRIPTION
Use INFO logging over printing to STDOUT. Remove unused futures
executor.

### Linked Issue(s)
Closes #49 